### PR TITLE
Add support for Llama2, Palm, Cohere, Anthropic, Replicate, Azure Models - using litellm

### DIFF
--- a/lwe/backends/api/backend.py
+++ b/lwe/backends/api/backend.py
@@ -3,6 +3,7 @@ import threading
 import tiktoken
 
 from langchain.chat_models.openai import ChatOpenAI
+from langchain.chat_models import ChatLiteLLM
 from langchain.schema import BaseMessage
 from langchain.chat_models.openai import _convert_message_to_dict
 
@@ -698,7 +699,7 @@ class ApiBackend(Backend):
             ]
             new_messages = self.transform_messages_to_chat_messages(new_messages)
             new_messages = self.provider.prepare_messages_for_llm_chat(new_messages)
-            llm = ChatOpenAI(model_name=constants.API_BACKEND_DEFAULT_MODEL, temperature=0)
+            llm = ChatLiteLLM(model_name=constants.API_BACKEND_DEFAULT_MODEL, temperature=0)
             try:
                 result = llm(new_messages)
                 title = self._extract_message_content(result)['message']

--- a/lwe/plugins/provider_chat_openai.py
+++ b/lwe/plugins/provider_chat_openai.py
@@ -1,9 +1,10 @@
 from langchain.chat_models.openai import ChatOpenAI
+from langchain.chat_models import ChatLiteLLM
 
 from lwe.core.provider import Provider, PresetValue
 from lwe.core import constants
 
-class CustomChatOpenAI(ChatOpenAI):
+class CustomChatOpenAI(ChatLiteLLM):
     @property
     def _llm_type(self):
         """Return type of llm."""


### PR DESCRIPTION
This PR adds support for 50+ models using liteLLM : https://github.com/BerriAI/litellm/

`ChatLiteLLM()` is integrated into langchain and allows you to call all models using the ChatOpenAI I/O interface 
https://python.langchain.com/docs/integrations/chat/litellm

Here's an example of how to use ChatLiteLLM()
```python
ChatLiteLLM(model="gpt-3.5-turbo")
ChatLiteLLM(model="claude-2", temperature=0.3)
ChatLiteLLM(model="command-nightly")
ChatLiteLLM(model="replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1")

```