### PR TITLE
Fix bug for building DockerFile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,18 @@ FROM python:3
 USER root
 
 # Pkgs for default database.
-RUN apt-get update && apt-get install -y sqlite3
+# Workaround for installing newer Rust compiler
+ENV PATH="/root/.cargo/bin:$PATH"
+RUN apt-get update && apt-get install -y --no-install-recommends curl gcc &&  curl https://sh.rustup.rs -sSf | sh -s -- -y && apt-get install --reinstall libc6-dev -y
 
 # Editor packages.
-RUN apt-get install -y vim vim-airline vim-ctrlp
+RUN apt-get install -y sqlite3 vim vim-airline vim-ctrlp
 
 COPY requirements.txt /tmp/requirements.txt
 
-RUN pip install -r /tmp/requirements.txt
+
+RUN pip install --upgrade pip & \
+    pip install -r /tmp/requirements.txt
 
 COPY . /src
 WORKDIR /src


### PR DESCRIPTION
The pip package 'tiktoken', defined in requirements.txt, can only be built using a newer version of the Rust compiler than the one provided by the python:3 image (Debian based distro).

The solution was to download and install the newest version or Rust. More information can be see in this thread: https://github.com/openai/tiktoken/issues/23

Although it is a workaround, it now installs all packages.  